### PR TITLE
Fix arrow symbol in comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@ body, html {
   border-radius: 4px;
   display: flex;
   flex-direction: column;
-  align-items: stretch; /* <– wichtig für volle Breite */
+  align-items: stretch; /* <- wichtig für volle Breite */
   z-index: 200;
 }
     .window-taskbar { background:var(--hdr); padding:6px 8px; cursor:grab; display:flex; align-items:center; color:#fff; }

--- a/index1.html
+++ b/index1.html
@@ -137,7 +137,7 @@ body, html {
   border-radius: 4px;
   display: flex;
   flex-direction: column;
-  align-items: stretch; /* <– wichtig für volle Breite */
+  align-items: stretch; /* <- wichtig für volle Breite */
   z-index: 200;
 }
     .window-taskbar { background:var(--hdr); padding:6px 8px; cursor:grab; display:flex; align-items:center; color:#fff; }


### PR DESCRIPTION
## Summary
- fix incorrect arrow in `index.html` and `index1.html`

## Testing
- `grep -n "wichtig f" index.html index1.html`

------
https://chatgpt.com/codex/tasks/task_e_6859ae12616c83319465c1a16d41e399